### PR TITLE
remove dependencies on precomputeStyle and logError

### DIFF
--- a/lib/RefresherListView.js
+++ b/lib/RefresherListView.js
@@ -1,6 +1,4 @@
 var React = require('react-native');
-var precomputeStyle = require('precomputeStyle');
-var logError = require('logError');
 var LoadingActivityIndicatorIOS = require('./indicators/LoadingActivityIndicatorIOS');
 var isPromise = require('is-promise')
 
@@ -139,9 +137,9 @@ class RefresherListView extends React.Component {
         let listview = this.refs.listview;
         let listviewscroll = listview.getScrollResponder();
         this.requestAnimationFrame(() => {
-            listviewscroll.setNativeProps(precomputeStyle({contentInset:{top:threshold}}));
-            listviewscroll.refs.InnerScrollView.setNativeProps(precomputeStyle({paddingTop:threshold}))
-            listview.setNativeProps(precomputeStyle({top:-threshold,bottom:0}))
+            listviewscroll.setNativeProps({style:{contentInset:{top:threshold}}});
+            listviewscroll.refs.InnerScrollView.setNativeProps({style:{paddingTop:threshold}})
+            listview.setNativeProps({style:{top:-threshold,bottom:0}})
         });
     }
 
@@ -185,7 +183,7 @@ class RefresherListView extends React.Component {
     renderIndicator() {
         let Indicator = this.props.indicator;
         return cloneElement(Indicator, {
-            ref: (indicator => {this.refs.indicator = indicator || this.refs.indicator}.bind(this)),
+            ref: (indicator => {this.refs.indicator = indicator || this.refs.indicator}),
             status: this.state.loadingStatus,
             height: this.getIndicatorHeight(),
             threshold: this.state.threshold


### PR DESCRIPTION
This is close to getting this working again.  Is this project still alive? :)

There is one bug I can't figure out.  In the LoadingBarIndicator.js file, the line
`var NativeMethodsMixin = require('NativeMethodsMixin')`
throws an error, saying it can't find the NativeMethodsMixin module.  Not sure why?!?  I can load it with the same line of code directly in my project.  Any ideas?
